### PR TITLE
add docs url to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Suggests:
     testit,
     testthat (>= 2.1.0),
     tracerer
-URL: https://github.com/ropensci/beastier
+URL: https://docs.ropensci.org/beastier (website)
+    https://github.com/ropensci/beastier
 BugReports: https://github.com/ropensci/beastier
 Language: en-US
 VignetteBuilder: knitr


### PR DESCRIPTION
Hello!

The official [rOpenSci docs server](https://docs.ropensci.org) which we [announced](https://ropensci.org/technotes/2019/06/07/ropensci-docs/) in June is fully ready for production now:

 - Official documentation URL: https://docs.ropensci.org/beastier
 - Website build logs: https://dev.ropensci.org/job/beastier (click "last build" -> "console output")

If all seems good, we strongly suggest to add the URL to the package DESCRIPTION file and include this in the next CRAN update. This has two major benefits:

  - Pkgdown does automatic [cross-linking](https://pkgdown.r-lib.org/dev/articles/linking.html) to other pkgdown sites that can be found via CRAN. This means that if another package refers to your package in an example or vignette, their pkgdown site automatically hyperlinks those functions to your pkgdown site (if your pkgdown URL has been published on CRAN!)
  - Because our documentation is hosted under a single official domain `docs.ropensci.org` this will accumulate a higher pagerank than when a site are scattered over github or custom places. This should make it easier to find these documentation sites on Google and others.

We hope that this service will make it easy to maintain high quality and visible documentation for your packages! If something is unclear or not working, feel free to ask questions here or on slack.
