### PR TITLE
Use h1 for versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,277 +2,277 @@
 
 Newest versions at top.
 
-## beastier 2.5.1 (unreleased)
+# beastier 2.5.1 (unreleased)
 
-### NEW FEATURES
-
-  * None
-
-### MINOR IMPROVEMENTS
+## NEW FEATURES
 
   * None
 
-### BUG FIXES
+## MINOR IMPROVEMENTS
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## BUG FIXES
 
   * None
 
-## beastier 2.5 (2023-11-07)
-
-### NEW FEATURES
+## DEPRECATED AND DEFUNCT
 
   * None
 
-### MINOR IMPROVEMENTS
+# beastier 2.5 (2023-11-07)
+
+## NEW FEATURES
+
+  * None
+
+## MINOR IMPROVEMENTS
 
   * Remove dependency on 'assertive'
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.12 (2023-09-25)
+# beastier 2.4.12 (2023-09-25)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
  * Use new CITATION style
  * Did `usethis::use_package_doc()`
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.11 (2022-08-11)
+# beastier 2.4.11 (2022-08-11)
 
-### NEW FEATURES
-
-  * None
-
-### MINOR IMPROVEMENTS
+## NEW FEATURES
 
   * None
 
-### BUG FIXES
+## MINOR IMPROVEMENTS
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## BUG FIXES
+
+  * None
+
+## DEPRECATED AND DEFUNCT
 
   * 'is_on_ci' is now 'beautier::is_on_ci'
 
-## beastier 2.4.10 (2022-06-16)
+# beastier 2.4.10 (2022-06-16)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Add 'remove_beaustier_folders' to delete both the 'beautier' and 'beastier' temporary folders
   * Add 'check_empty_beaustier_folders' to check that both the 'beautier' and 'beastier' temporary folders are empty
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.9 (2022-06-03)
+# beastier 2.4.9 (2022-06-03)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Also deletes the temporary 'beastier' folder
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.8 (2021-09-19)
+# beastier 2.4.8 (2021-09-19)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * `check_empty_beastier_folder` works under Windows
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.7 (2021-09-06)
+# beastier 2.4.7 (2021-09-06)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Allow to use treelog, screenlog and tracelog filenames in absent
     sub-sub-subfolders, fixes babette bug
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.6 (only released on CRAN)
+# beastier 2.4.6 (only released on CRAN)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Improved documentation, thanks Julia Haider
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.5 (2021-08-18)
+# beastier 2.4.5 (2021-08-18)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Improved error handling
   * Less whitespace in `beastier_report`
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.4 (2021-08-17)
+# beastier 2.4.4 (2021-08-17)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Produces no undeleted temporary files
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.3 (2021-07-09)
+# beastier 2.4.3 (2021-07-09)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * `check_can_create_file` creates folder if needed
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.2 (2021-06-04)
+# beastier 2.4.2 (2021-06-04)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Tested to work on Windows
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4.1 (2021-05-30)
+# beastier 2.4.1 (2021-05-30)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Cleans up all created temporary files
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.4 (2021-05-22)
+# beastier 2.4 (2021-05-22)
 
-### NEW FEATURES
-
-  * None
-
-### MINOR IMPROVEMENTS
+## NEW FEATURES
 
   * None
 
-### BUG FIXES
+## MINOR IMPROVEMENTS
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## BUG FIXES
+
+  * None
+
+## DEPRECATED AND DEFUNCT
 
   * `install_beast2`, `upgrade_beast2`, `uninstall_beast2` are deprecated,
     as these violated CRAN policy. Thanks to Brian Ripley for sharing!
@@ -280,17 +280,17 @@ Newest versions at top.
     `beastierinstall` package at `https://github.com/richelbilderbeek/beastierinstall`
   * Removed deprecated function `update_beastier`
 
-## beastier 2.3.1 (2021-05-15)
+# beastier 2.3.1 (2021-05-15)
 
-### NEW FEATURES
-
-  * None
-
-### MINOR IMPROVEMENTS
+## NEW FEATURES
 
   * None
 
-### BUG FIXES
+## MINOR IMPROVEMENTS
+
+  * None
+
+## BUG FIXES
 
   * Can correctly call BEAST2 when spaces in 
     (1) BEAST2 bin filename, 
@@ -299,72 +299,72 @@ Newest versions at top.
     (4) BEAST2 state output filename.
     Thanks Jason Griffiths
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.3 (2021-05-14)
+# beastier 2.3 (2021-05-14)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * Add `continue_beast2` to continue a BEAST2 run
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Builds on GitHub Actions
   * Added `is_on_github_actions` to detect the GitHub Actions environment
   * `is_on_ci` detects the GitHub Actions environment
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * `update_beastier`: gives deprecation message
 
-## beastier 2.2.1 (2020-10-31)
+# beastier 2.2.1 (2020-10-31)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * `get_default_beast2_jar_path` allows for a custom folder name
   * `install_beast2` is silent by default
   * `install_beast2` and `uninstall_beast2` give more information when
     verbose
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.2 (2020-10-16)
+# beastier 2.2 (2020-10-16)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * Add 'create_mcbette_beast2_options'
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * No `testthat` tests in code examples
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.1.3 (2020-08-05)
+# beastier 2.1.3 (2020-08-05)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * Add `rename_beast2_options_filenames`
   * Add `get_beast2_options_filenames`
@@ -372,70 +372,70 @@ Newest versions at top.
   * Add `beastier_report` to help create a bug report
   * Can `install_beast2` for a specific version
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Enable MacOS build again
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.1.2 (2020-01-06)
+# beastier 2.1.2 (2020-01-06)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Documentation at [rOpenSci](https://docs.ropensci.org/beastier) to
     shows pictures
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.1.1 (2019-12-02)
+# beastier 2.1.1 (2019-12-02)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * Add vignettes
   
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * None
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.1 (2019-10-27)
+# beastier 2.1 (2019-10-27)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * Follows `beautier` v2.3 interface
   
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * None
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * The function arguments `beast2_output_log_filename` 
     and `beast2_output_trees_filename` have become obsolete. Use
@@ -444,9 +444,9 @@ Newest versions at top.
   * The function argument `beast2_working_dir` is obsoleted, because it
     no longer served a purpose. Use `setwd` to set the working directory 
 
-## beastier 2.0.25 (2019-10-10)
+# beastier 2.0.25 (2019-10-10)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * Add `get_beast2_example_filenames` to get the
     full paths of all the BEAST2 example files
@@ -456,168 +456,168 @@ Newest versions at top.
     the default BEAST2 working directory
   * Add `clear_beast2_working_dir` to clear the BEAST2 working directory
   
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * None
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
 
-## beastier 2.0.24 (2019-09-30)
+# beastier 2.0.24 (2019-09-30)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Do not check if `beast2_path` still/already exists in `check_beast2_options`
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.23 (2019-09-29)
+# beastier 2.0.23 (2019-09-29)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * Use BEAST2 main class name when calling the jar file, 
     to fix the 'no main manifest attribute' error
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * None
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.22 (2019-09-16)
+# beastier 2.0.22 (2019-09-16)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Add `update_beastier` to update the `beastier` dependencies
   * Lowered cyclomatic complexity, thanks @lintr-bot 
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.21 (2019-09-10)
+# beastier 2.0.21 (2019-09-10)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * `create_beast2_options` checks that the filenames are not in the same
     folder as the BEAST2 working directory
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.20 (2019-08-27)
+# beastier 2.0.20 (2019-08-27)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Added `get_beast2_options_filenames` to obtain the filenames in a
     `beast2_options` 
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
 
-## beastier 2.0.19 (2019-08-23)
+# beastier 2.0.19 (2019-08-23)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * `check_beast2_options` checks for duplicate filenames
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.18 (2019-08-14)
+# beastier 2.0.18 (2019-08-14)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * Install BEAST2 `v2.6.0`, instead of `v2.5.2`
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Can create files in sub-sub-subfolders
   * Builds on Travis CI distribution 'Bionic'
   * Add `are_identical_alignments`
   * Add `is_alignment`
 
-### BUG FIXES
+## BUG FIXES
 
   * RNG seed is checked to be a whole number (Issue #35, thanks @thijsjanzen)
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.17
+# beastier 2.0.17
 
 This version never had a formal release.
 
-## beastier 2.0.16
+# beastier 2.0.16
 
 This version never had a formal release.
 
-## beastier 2.0.15 (2019-06-01)
+# beastier 2.0.15 (2019-06-01)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Simplified `run_beast2`
   * Improved error checking and logging in `run_beast2`
@@ -625,186 +625,186 @@ This version never had a formal release.
   * Removed example code that assumed all Linuxes have `/home/username`,
     thanks to Brian Ripley 
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.14 (2019-05-27)
+# beastier 2.0.14 (2019-05-27)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Add `SystemRequirements` field to `DESCRIPTION`
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.13 (2019-05-14)
+# beastier 2.0.13 (2019-05-14)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * Install BEAST2 `v2.5.2`, instead of `v2.5.1`
   * Can call `run_beast2`/`run_beast2_from_options` in parallel
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * None
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.12 (2019-04-08)
+# beastier 2.0.12 (2019-04-08)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Package builds successfully without BEAST2 installed
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.11 (2019-03-27)
+# beastier 2.0.11 (2019-03-27)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * `get_default_beast2_bin_path` is silent if BEAST2 is absent
   * Package builds successfully without BEAST2 installed
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.10 (2019-03-26)
+# beastier 2.0.10 (2019-03-26)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Passes tests without BEAST2 installed
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.9 (2019-03-26)
+# beastier 2.0.9 (2019-03-26)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Pass local CRAN tests
   * Shortened examples' runtime 
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.8 (2019-03-26)
+# beastier 2.0.8 (2019-03-26)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Fix spelling error
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.7 (2019-03-26)
+# beastier 2.0.7 (2019-03-26)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Documentation examples work on macOS
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.6 (2019-03-25)
+# beastier 2.0.6 (2019-03-25)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Whitelist 'Schmirl'
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.5 (2019-03-25)
+# beastier 2.0.5 (2019-03-25)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * CRAN and rOpenSci release candidate
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Implemented feedback from CRAN, thanks Martina Schmirl:
     * In DESCRIPTION, use `'R'` for programs
@@ -813,161 +813,161 @@ This version never had a formal release.
     * In DESCRIPTION, use only `GPL-3` instead of also adding the file `LICENSE`
     * Add examples to all functions
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0.1 (2019-03-15)
+# beastier 2.0.1 (2019-03-15)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * CRAN and rOpenSci release candidate
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * None
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 2.0 (2019-01-04)
+# beastier 2.0 (2019-01-04)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * GitHub repository is owned by `ropensci`
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * None
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 1.5.2 (2018-10-30)
+# beastier 1.5.2 (2018-10-30)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Tested to work under macOS
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 1.5.1 (2018-10-26)
+# beastier 1.5.1 (2018-10-26)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Made up-to-date with newer version of `beautier`
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 1.5 (2018-09-12)
+# beastier 1.5 (2018-09-12)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Instead of supplying a BEAST2 `.jar` path 
     (using the argument `beast2_jar_path`), one
     can now also supply the BEAST2 binary path.
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * All parameters named `beast2_jar_path` are now called `beast2_path`
 
 
-## beastier 1.4.4 (2018-08-05)
+# beastier 1.4.4 (2018-08-05)
 
-### NEW FEATURES
-
-  * None
-
-### MINOR IMPROVEMENTS
+## NEW FEATURES
 
   * None
 
-### BUG FIXES
+## MINOR IMPROVEMENTS
+
+  * None
+
+## BUG FIXES
 
   * `run_beast2` had a parameter called `overwrite_state_file`, which is renamed 
     to `overwrite` and states if the `.log` file and `.trees` files will be overwritten, 
     like BEAST2 does. This is a bug fix, as the obsolete parameter name did not
     prevent the state file being overwritten.
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * Calling `run_beast2` with a parameter called `overwrite_state_file` is obsolete. 
     Use the parameter `overwrite` instead.
 
-## beastier 1.4.3 (2018-05-17)
+# beastier 1.4.3 (2018-05-17)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Tagged for [the academic article about `babette`](https://github.com/richelbilderbeek/babette_article)
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None
 
-## beastier 1.4.2 (2018-04-05)
+# beastier 1.4.2 (2018-04-05)
 
-### NEW FEATURES
+## NEW FEATURES
 
   * None
 
-### MINOR IMPROVEMENTS
+## MINOR IMPROVEMENTS
 
   * Follow all [rOpenSci packaging guidelines](https://github.com/ropensci/onboarding/blob/master/packaging_guide.md)
 
-### BUG FIXES
+## BUG FIXES
 
   * None
 
-### DEPRECATED AND DEFUNCT
+## DEPRECATED AND DEFUNCT
 
   * None


### PR DESCRIPTION
Hi @richelbilderbeek,

With this Pull Request I'd would like to make the changelog appear on the website. https://docs.ropensci.org/beastier/news/index.html.

Basically did Find / Replace all "##" -. "#" to remove one level of indentation

pkgdown only recognizes h1 for versions

Sure, I've read [CONTRIBUTING.md](https://github.com/ropensci/beautier/blob/master/CONTRIBUTING.md) :+1:

Cheers, Olivier

https://pkgdown.r-lib.org/reference/build_news.htm